### PR TITLE
Implement silence check and user activity tracking

### DIFF
--- a/db.py
+++ b/db.py
@@ -19,4 +19,18 @@ async def init():
         """)
         await db.commit()
 
+async def touch_user(user_id: int) -> None:
+    """Update last_seen for a user or create the record."""
+    now = dt.datetime.utcnow().isoformat()
+    async with aiosqlite.connect(DB) as db:
+        await db.execute(
+            """
+            INSERT INTO users (user_id, last_seen)
+            VALUES (?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET last_seen=excluded.last_seen
+            """,
+            (user_id, now),
+        )
+        await db.commit()
+
 asyncio.run(init())


### PR DESCRIPTION
## Summary
- update database with a `touch_user` helper
- ping inactive users in the scheduler
- start the reminder scheduler in `post_init`
- record `last_seen` for every incoming message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880a480707c832e99690c3f1646c413