### PR TITLE
Initialize db during post_init

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,6 +1,5 @@
 import aiosqlite
 import datetime as dt
-import asyncio
 
 DB = "buddy.db"
 
@@ -24,6 +23,11 @@ async def init() -> None:
             """
         )
         await db.commit()
+
+
+async def init_db() -> None:
+    """Initialize the database tables."""
+    await init()
 
 
 async def update_last_seen(user_id: int, seen: dt.datetime | None = None) -> None:
@@ -92,4 +96,3 @@ async def add_reminder(
         await db.commit()
 
 
-asyncio.run(init())

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from telegram.ext import (
 from gpt import ask_gpt
 from scheduler import start_scheduler
 from db import touch_user, add_reminder
+import db
 import datetime as dt
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -98,6 +99,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 # post_init ­– выполняется сразу после инициализации Application
 # ---------------------------------------------------------------------------
 async def post_init(app: Application) -> None:
+    await db.init_db()
     # 1) health‑роут
     app.web_app.router.add_get("/healthz", health)
     logger.info("Health route / зарегистрирован")


### PR DESCRIPTION
## Summary
- make DB init callable via `init_db()`
- set up bot to call `await db.init_db()` during `post_init`

## Testing
- `python -m py_compile db.py main.py scheduler.py gpt.py prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_6880af1289b8832ea7e534224a8b549d