### PR TITLE
Add OPENAI_MODEL env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ Follow these steps to deploy the bot to [Fly.io](https://fly.io).
                   ADMIN_CHAT_ID=<telegram-id> \
                   OPENAI_MODEL=gpt-4.1
    ```
+   `OPENAI_MODEL` selects the model used in both `gpt.py` and `scheduler.py`. If
+   not set, they default to `gpt-4.1`.
 4. **Push to the `main` branch**. A GitHub Actions workflow automatically deploys the app whenever you push to `main`.

--- a/gpt.py
+++ b/gpt.py
@@ -3,11 +3,13 @@ from openai import AsyncOpenAI
 from prompts import SYSTEM_PROMPT
 
 client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+# OpenAI model can be set via environment variable
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
 
 async def ask_gpt(text: str) -> str:
-    """Send text to OpenAI GPT-4.1 and return the response."""
+    """Send text to the configured OpenAI model and return the response."""
     chat = await client.chat.completions.create(
-        model="gpt-4.1",
+        model=OPENAI_MODEL,
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": text},


### PR DESCRIPTION
## Summary
- configure `gpt.py` to read `OPENAI_MODEL` from the environment
- mention the default model in README

## Testing
- `python -m py_compile gpt.py scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_6880afdc140c832e81d003d89bee3dd1